### PR TITLE
Update NodeJS version in CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     apt-get install -y rename && \
     apt-get install -y zsh
 
-RUN curl -sL https://deb.nodesource.com/setup_11.x  | bash -
+RUN curl -sL https://deb.nodesource.com/setup_15.x  | bash -
 
 RUN apt-get update && \
     apt-get install -y nodejs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v1
         with:
-          node-version: "11"
+          node-version: "15"
       - name: Restore deps cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
## ✍️ Description

This PR bumps the NodeJS version from 11 to 15.

## ✅ Fixes

None

## ✅ QA

None

## 📸 Screenshots

None

## 🔗 Relevant URLs

* https://nodejs.org/en/about/releases/

## 📕Extra Documentation

None