### PR TITLE
Change porwerlevel zsh theme to avit

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,2 +1,3 @@
 ## setup and install oh-my-zsh
 sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.0.2/zsh-in-docker.sh)"
+sed -i -e "s/powerlevel10k\/powerlevel10k/avit/g" /root/.zshrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           cp dev.exs.example dev.exs
           cp test.exs.example test.exs
       - name: Set up Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           elixir-version: "1.11.2" # Define the elixir version [required]
           otp-version: "23.0" # Define the OTP version [required]


### PR DESCRIPTION
## ✍️ Description

(required) Please include any relevant details about this Pull Request, with a focus on:

I'd like to suggest changing the zsh theme from `powerlevel` to `avit` as powerlevel needs fonts that have some specials characters and if the font is not installed can be some missing character in the terminal.

Also I updated the setup-elixir action that now is maintained in the repo `erlef/setup-elixir`


## 📸 Screenshots

(optional) Please post any relevant screenshots that might help understanding the scope of this functionality.

Using powelevel theme
![image](https://user-images.githubusercontent.com/52708/112303387-83442480-8c9c-11eb-82cb-32fd86888a02.png)

Using avit theme
![image](https://user-images.githubusercontent.com/52708/112303617-c7cfc000-8c9c-11eb-8c15-00ffd154cda1.png)
