### PR TITLE
Remove VSCode CSS files reassociation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,9 +3,6 @@
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "stylelint.configBasedir": "assets",
-  "files.associations": {
-    "*.css": "postcss"
-  },
   "eslint.workingDirectories": ["./assets"],
   "eslint.nodePath": "assets",
   "[javascript]": {


### PR DESCRIPTION
## ✍️ Description

Not sure why, but by default this project settings map the CSS files as "postcss" using VSCode. This PR removes that.

## ✅ Fixes

Dev setup