### PR TITLE
Automerge dependabot PRs matching minor/patch versions

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,15 @@
+name: Dependabot automerge
+
+on:
+  pull_request_target:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          command: "squash and merge"
+          github-token: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
## ✍️ Description

This PR adds a way to automatically merge dependabot PRs matching minor/patch versions. Major version upgrades won't be automerged.